### PR TITLE
when showing password, also show usernae

### DIFF
--- a/onepassword/cli.py
+++ b/onepassword/cli.py
@@ -34,7 +34,7 @@ class CLI(object):
         )
 
         if item is not None:
-            self.stdout.write("%s\n" % item.password)
+            self.stdout.write("%s: %s\n" % (item.name, item.password))
         else:
             self.stderr.write("1pass: Could not find an item named '%s'\n" % (
                 self.arguments.item,

--- a/onepassword/keychain.py
+++ b/onepassword/keychain.py
@@ -126,6 +126,10 @@ class KeychainItem(object):
         decrypted_json = key.decrypt(self._encrypted_json)
         self._data = json.loads(decrypted_json)
         self.password = self._find_password()
+        self.name = self._find_username()
+
+    def _find_username(self):
+        return ""
 
     def _find_password(self):
         raise Exception("Cannot extract a password from this type of"
@@ -154,6 +158,12 @@ class WebFormKeychainItem(KeychainItem):
                field.get("name") == "Password":
                 return field["value"]
 
+    def _find_username(self):
+        for field in self._data["fields"]:
+            if field.get("designation") == "username" or \
+               field.get("name") == "username":
+                return field["value"]
+        
 
 class PasswordKeychainItem(KeychainItem):
     def _find_password(self):


### PR DESCRIPTION
Howdy!

I saw your modification for showing *all* the matching 1Password items, and improved on it a bit: now you can see the password AND the username of the selected item.

Thanks! Let me know if there's anything I need to do to get this accepted
_Ryan Wilcox